### PR TITLE
Rules: Match the correct gnupg package for Gentoo

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -391,8 +391,9 @@
 - { namepat: "gnet[0-9]+",             setname: gnet }
 - { name: gnet, verpat: "1\\..*",      setname: gnet1 }
 
-- { namepat: "gnupg[0-9]+",            setname: gnupg }
-- { name: gnupg, verpat: "1\\..*",     setname: gnupg1 }
+- { namepat: "gnupg[0-9]+",                               setname: gnupg }
+- { name: gnupg, verpat: "1\\..*",                        setname: gnupg1 }
+- { family: [ gentoo ], category: app-crypt, name: gnupg, setname: gnupg }
 
 - { name: glusterfs3,                  setname: glusterfs }
 


### PR DESCRIPTION
Gentoo GNU Linux has two packages named "gnupg":

 - app-crypt/gnupg
 - app-vim/gnupg

Repology is currently comparing against app-vim/gnupg, see http://repology.org/metapackage/gnupg/versions

This PR tries to match the correct package. Hope that's working like intended following your documentation. Haven't tried with real data.